### PR TITLE
Fix segfault in  thread if user watch_cb is NULL

### DIFF
--- a/dmon.h
+++ b/dmon.h
@@ -438,6 +438,10 @@ _DMON_PRIVATE void dmon__win32_process_events(void)
         }
         dmon__watch_state* watch = &_dmon.watches[ev->watch_id.id - 1];
 
+        if(watch == NULL || watch->watch_cb == NULL) {
+            continue;
+        }
+
         switch (ev->action) {
         case FILE_ACTION_ADDED:
             watch->watch_cb(ev->watch_id, DMON_ACTION_CREATE, watch->rootdir, ev->filepath, NULL,
@@ -855,6 +859,10 @@ _DMON_PRIVATE void dmon__inotify_process_events(void)
         }
         dmon__watch_state* watch = &_dmon.watches[ev->watch_id.id - 1];
 
+        if(watch == NULL || watch->watch_cb == NULL) {
+            continue;
+        }
+
         switch (ev->mask) {
         case IN_CREATE:
             watch->watch_cb(ev->watch_id, DMON_ACTION_CREATE, watch->rootdir, ev->filepath, NULL,
@@ -1225,6 +1233,10 @@ _DMON_PRIVATE void dmon__fsevent_process_events(void)
             continue;
         }
         dmon__watch_state* watch = &_dmon.watches[ev->watch_id.id - 1];
+
+        if(watch == NULL || watch->watch_cb == NULL) {
+            continue;
+        }
 
         if (ev->event_flags & kFSEventStreamEventFlagItemCreated) {
             watch->watch_cb(ev->watch_id, DMON_ACTION_CREATE, watch->rootdir, ev->filepath, NULL,


### PR DESCRIPTION
I'm currently writing a wrapper for dmon the V programming language
and encountered a segfault in the watch thread after using `dmon_unwatch`.
The crash occurs because the user callback pointer is non-existent after the call to `dmon_unwatch`.
```
dmon.init
dmon.watch: watching "/tmp/wt"
dmon.c_watch_callback_wrap: filesystem event (1) "modify" in "/tmp/wt/" modified "/tmp/wt/2/ftest_test"
dmon.c_watch_callback_wrap: filesystem event (1) "modify" in "/tmp/wt/" modified "/tmp/wt/test_test"
dmon.c_watch_callback_wrap: filesystem event (1) "move" in "/tmp/wt/" moved "/tmp/wt/test_test" to "/tmp/wt/test"
dmon.c_watch_callback_wrap: filesystem event (1) "delete" in "/tmp/wt/" deleted "/tmp/wt/test"
dmon.watch: watching "/tmp/wt/3/4/5/6/7"
dmon.un_watch: unwatching "2"
dmon.un_watch: removing "2/1"
Segmentation fault (core dumped)
```

This PR fixes this by checking for NULL before calling the user callback.