### PR TITLE
Fix Reinitialization

### DIFF
--- a/dmon.h
+++ b/dmon.h
@@ -611,13 +611,13 @@ DMON_API_IMPL void dmon_deinit(void)
             if (_dmon.watches[i]) {
                 _dmon_unwatch(_dmon.watches[i]);
                 DMON_FREE(_dmon.watches[i]);
-                _dmon.watches[i] = NULL;
             }
         }
     }
 
     DeleteCriticalSection(&_dmon.mutex);
     stb_sb_free(_dmon.events);
+    memset(&_dmon, 0x0, sizeof(_dmon));
     _dmon_init = false;
 }
 
@@ -1156,13 +1156,13 @@ DMON_API_IMPL void dmon_deinit(void)
             if (_dmon.watches[i]) {
                 _dmon_unwatch(_dmon.watches[i]);
                 DMON_FREE(_dmon.watches[i]);
-                _dmon.watches[i] = NULL;
             }
         }
     }
 
     pthread_mutex_destroy(&_dmon.mutex);
     stb_sb_free(_dmon.events);
+    memset(&_dmon, 0x0, sizeof(_dmon));
     _dmon_init = false;
 }
 
@@ -1547,7 +1547,6 @@ DMON_API_IMPL void dmon_deinit(void)
             if (_dmon.watches[i]) {
                 _dmon_unwatch(_dmon.watches[i]);
                 DMON_FREE(_dmon.watches[i]);
-                _dmon.watches[i] = NULL;
             }
         }
     }
@@ -1557,6 +1556,7 @@ DMON_API_IMPL void dmon_deinit(void)
     if (_dmon.cf_alloc_ref)
         CFRelease(_dmon.cf_alloc_ref);
 
+    memset(&_dmon, 0x0, sizeof(_dmon));
     _dmon_init = false;
 }
 


### PR DESCRIPTION
Hi, while testing on Linux I noticed that directory monitoring wasn't working properly after reinitializing the library.  `dmon_deinit` was leaving `_dmon.quit` set to `true`, so the monitoring thread exited immediately on the second run.  This patch changes `dmon_deinit` to reset all the state back to zero, just to be safe.  This fixes the issue for me.