### PR TITLE
Fix an unsigned warning

### DIFF
--- a/dmon.h
+++ b/dmon.h
@@ -865,7 +865,7 @@ _DMON_PRIVATE void _dmon_gather_recursive(dmon__watch_state* watch, const char* 
                 _dmon_strcpy(subdir.rootdir, sizeof(subdir.rootdir), newdir + strlen(watch->rootdir));
             }
 
-            dmon__inotify_event dev = { { 0 }, IN_CREATE|(is_dir ? IN_ISDIR : 0), 0, watch->id, false };
+            dmon__inotify_event dev = { { 0 }, IN_CREATE|(is_dir ? IN_ISDIR : 0U), 0, watch->id, false };
             _dmon_strcpy(dev.filepath, sizeof(dev.filepath), subdir.rootdir);
             stb_sb_push(_dmon.events, dev);
         }


### PR DESCRIPTION
Fix the following warning:

```
/home/glow/dev/f3d/f3d/src/external/dmon/dmon.h:869:57: warning: narrowing conversion of ‘(256 | (is_dir ? 1073741824 : 0))’ from ‘int’ to ‘uint32_t’ {aka ‘unsigned int’} [-Wnarrowing]
  869 |             dmon__inotify_event dev = { { 0 }, IN_CREATE|(is_dir ? IN_ISDIR : 0), 0, watch->id, false };
      |                                                         ^
^Cmake[2]: *** [application/CMakeFiles/f3d.dir/build.make:126: application/CMakeFiles/f3d.dir/F3D, 0, watch->id, false };
```